### PR TITLE
Fixed webpacker dev server port in docker dev mode.

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -59,7 +59,7 @@ development:
   dev_server:
     https: false
     host: localhost
-    port: 13035
+    port: 3035
     public: localhost:13035
     hmr: false
     # Inline should be set to true if using HMR


### PR DESCRIPTION
Log in console: Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://localhost:13035/sockjs-node/info?t=1617254776608. (Reason: CORS request did not succeed)